### PR TITLE
Remove usings where not necessary.

### DIFF
--- a/PayPalPermissionsSDK/PayPalPermissionsSDK.csproj
+++ b/PayPalPermissionsSDK/PayPalPermissionsSDK.csproj
@@ -29,20 +29,12 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Newtonsoft.Json, Version=4.5.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>lib\Newtonsoft.Json.dll</HintPath>
-    </Reference>
     <Reference Include="PayPalCoreSDK, Version=1.6.0.0, Culture=neutral, PublicKeyToken=5b4afc1ccaef40fb, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>lib\PayPalCoreSDK.dll</HintPath>
     </Reference>
     <Reference Include="System" />
-    <Reference Include="System.configuration" />
-    <Reference Include="System.Data" />
     <Reference Include="System.Web" />
-    <Reference Include="System.Web.Services" />
-    <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Permissions\PayPalPermissionsModel.cs" />

--- a/PayPalPermissionsSDK/Permissions/PayPalPermissionsModel.cs
+++ b/PayPalPermissionsSDK/Permissions/PayPalPermissionsModel.cs
@@ -3,15 +3,11 @@
  * AUTO_GENERATED_CODE 
  */
 using System;
-using System.Collections;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Globalization;
 using System.Text;
-using System.Text.RegularExpressions;
 using System.Web;
-using System.Xml;
-using PayPal.Util;
 
 namespace PayPal.Permissions.Model
 {

--- a/PayPalPermissionsSDK/Permissions/PermissionsService.cs
+++ b/PayPalPermissionsSDK/Permissions/PermissionsService.cs
@@ -1,10 +1,6 @@
-using System;
 using System.Collections.Generic;
-using System.Xml;
-using PayPal;
 using PayPal.Authentication;
 using PayPal.Util;
-using PayPal.Manager;
 using PayPal.NVP;
 using PayPal.Permissions.Model;
 
@@ -12,11 +8,6 @@ namespace PayPal.Permissions
 {
 	public partial class PermissionsService : BasePayPalService 
 	{
-
-		/// <summary>
-		/// Service Version
-		/// </summary>
-		private const string ServiceVersion = "109.0";
 
 		/// <summary>
 		/// Service Name


### PR DESCRIPTION
Look's like api is deprecated. (Visual studio 2005, .net 2.0, commit frequency)
 If it is true maybe it will be reasonable to add information in *.md file like it was in "https://github.com/paypal/merchant-sdk-dotnet" about deprecation.